### PR TITLE
Disable the 'usb-logging' feature to resolve the linker errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 embedded-hal = "0.2"
 log = "0.4"
-teensy4-bsp = { version = "0.4", features = ["rt", "usb-logging"]}
+teensy4-bsp = { version = "0.4", features = ["rt"]}
 teensy4-panic = "0.2"
 rtic = { version = "2.0", features = ["thumbv7-backend"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ teensy4-panic = "0.2"
 rtic = { version = "2.0", features = ["thumbv7-backend"] }
 
 [profile.dev]
-lto = "thin"
+lto = false
 
 [profile.release]
 codegen-units = 1 # better optimizations
 debug = true # symbols are nice and they don't increase the size on Flash
-lto = true # "thin"
+lto = "fat"
 opt-level = "z"
 build-override = { opt-level = 0 }


### PR DESCRIPTION
The `usb-logging` feature provides a convenience for non-RTIC users. When enabled, the BSP defines `USB_OTG1`. This results in a duplicate definition once an RTIC application also defines `USB_OTG1`.

By disabling the feature, I can successfully build debug and release builds with non-`thin` LTO profiles. Heads up: I didn't test this on hardware.